### PR TITLE
FIX: correct boundary condition in EmphasisExtension token handling

### DIFF
--- a/src/renderer/src/cm-extensions/EmphasisExtension.ts
+++ b/src/renderer/src/cm-extensions/EmphasisExtension.ts
@@ -41,7 +41,7 @@ export const EmphasisExtension = ViewPlugin.fromClass(class {
 
         if (tokenElements.includes(node.name)) {
           widgets.push(tokenFormattingClasses[node.name].range(node.from, node.to))
-          if (from >= node.from && to <= node.to) {
+          if (from <= node.to && to >= node.from) {
             return false
           }
         }


### PR DESCRIPTION
This pull request includes an important fix to the `EmphasisExtension` in the `src/renderer/src/cm-extensions/EmphasisExtension.ts` file. The change corrects the condition for determining whether a token element should be formatted.

* [`src/renderer/src/cm-extensions/EmphasisExtension.ts`](diffhunk://#diff-5cb20c81fb083e4dcff03a181d38ceff21fa5bcd622771c73a42b8f03a0e5868L44-R44): Modified the condition in `EmphasisExtension` to correctly check the range of nodes - any overlapping selection would make the syntax visible.