### PR TITLE
Codeblock extension

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -30,6 +30,7 @@
         "js-yaml": "^4.1.0",
         "katex": "^0.16.21",
         "lodash": "^4.17.21",
+        "lucide": "^0.486.0",
         "lucide-react": "^0.475.0",
         "markdown-it": "^14.1.0"
       },
@@ -7385,6 +7386,12 @@
       "dependencies": {
         "yallist": "^3.0.2"
       }
+    },
+    "node_modules/lucide": {
+      "version": "0.486.0",
+      "resolved": "https://registry.npmjs.org/lucide/-/lucide-0.486.0.tgz",
+      "integrity": "sha512-3dvlZn/unTvbu7O0Ec9l+NF33qC0JnIuUmKQaY1kr5x2ItIwdEXrTA5QtoxD/126x9l8GHzSM9/g5a/skG9mUQ==",
+      "license": "ISC"
     },
     "node_modules/lucide-react": {
       "version": "0.475.0",

--- a/package.json
+++ b/package.json
@@ -39,6 +39,7 @@
     "js-yaml": "^4.1.0",
     "katex": "^0.16.21",
     "lodash": "^4.17.21",
+    "lucide": "^0.486.0",
     "lucide-react": "^0.475.0",
     "markdown-it": "^14.1.0"
   },

--- a/src/renderer/src/assets/Codeblock.scss
+++ b/src/renderer/src/assets/Codeblock.scss
@@ -17,6 +17,7 @@
  */
 .cm-formatting-codeblock-line-begin {
     @apply rounded-t-lg border-t border-l border-r border-gray-200 !important;
+    @apply h-8
 }
 
 /* 


### PR DESCRIPTION
This pull request includes several enhancements and bug fixes to the codebase, specifically focusing on the `CodeBlockExtension` and styling improvements. The most important changes are as follows:

Enhancements to `CodeBlockExtension`:

* Added a new `code` parameter to the `CodeLanguageIndicatorWidget` constructor to pass the code block content.
* Introduced a copy button to the code block language indicator, allowing users to copy the code block content to the clipboard.
* Modified the `toDOM` method to include the new copy button and adjusted styling for better alignment and spacing.

Styling improvements:

* Updated `Codeblock.scss` to set a fixed height for code block lines, improving visual consistency.

Dependency updates:

* Added the `lucide` library to `package.json` for using new icons in the code block extension.