### PR TITLE
Code gutter extension

### DIFF
--- a/src/renderer/src/assets/Editor.scss
+++ b/src/renderer/src/assets/Editor.scss
@@ -227,7 +227,7 @@ math {
   // padding: 0 5em 0 5em;
 }
 
-.cm-gutters {
+.cm-gutter.cm-lineNumbers {
   display: none !important;
 }
 

--- a/src/renderer/src/assets/Editor.scss
+++ b/src/renderer/src/assets/Editor.scss
@@ -227,8 +227,31 @@ math {
   // padding: 0 5em 0 5em;
 }
 
+/*
+ * hide the gutters for the dev process*/
 .cm-gutter.cm-lineNumbers {
   display: none !important;
+}
+
+.cm-gutter.cm-foldGutter {
+  display: none !important;
+}
+
+.cm-activeLineGutter {
+  background-color: transparent !important;
+}
+
+.cm-gutters {
+  background-color: transparent !important;
+  border: none !important;
+  font-size: 12px;
+}
+
+.cm-gutterElement {
+  display: flex;
+  justify-content: flex-end;
+  align-items: flex-end;
+  margin-right: 0.5em
 }
 
 body {

--- a/src/renderer/src/cm-extensions/CodeBlockGutterExtension.ts
+++ b/src/renderer/src/cm-extensions/CodeBlockGutterExtension.ts
@@ -1,0 +1,53 @@
+import { gutter, GutterMarker, EditorView } from "@codemirror/view";
+import { syntaxTree } from "@codemirror/language";
+import { SyntaxNodeRef } from "@lezer/common";
+
+class LineNumberMarker extends GutterMarker {
+  constructor(private number: number) {
+    super();
+  }
+  toDOM() {
+    return document.createTextNode(this.number.toString());
+  }
+}
+
+const getCodeBlockLines = (node: SyntaxNodeRef, view: EditorView): number[] => {
+  let lineStarts: number[] = [];
+  let docStateLines = view.state.doc.slice(node.from, node.to).iterLines();
+  let pos = node.from;
+
+  for (let line of docStateLines) {
+    lineStarts.push(pos);
+    pos += line.length + 1;
+  }
+  return lineStarts.slice(1, -1);
+};
+
+const codeBlockGutter = gutter({
+  lineMarker(view, line) {
+    let currentBlock: number[] = [];
+
+    syntaxTree(view.state).iterate({
+      enter: (node) => {
+        if (node.name === "FencedCode") {
+          const lines = getCodeBlockLines(node, view);
+          if (lines.includes(line.from)) {
+            currentBlock = lines;
+          }
+        }
+      },
+    });
+
+    if (currentBlock) {
+      let index = currentBlock.indexOf(line.from);
+      if (index !== -1) {
+        return new LineNumberMarker(index + 1);
+      }
+    }
+
+    return null;
+  },
+  class: "cm-codeblock-line-number",
+});
+
+export const CodeBlockGutterExtension = [codeBlockGutter];

--- a/src/renderer/src/cm-extensions/index.ts
+++ b/src/renderer/src/cm-extensions/index.ts
@@ -1,5 +1,6 @@
 import { BlockQuoteExtension } from "./BlockQuoteExtension";
 import { CodeBlockExtension } from "./CodeBlockExtension";
+import { CodeBlockGutterExtension } from "./CodeBlockGutterExtension";
 import { EmphasisExtension } from "./EmphasisExtension";
 import { FrontmatterExtension } from "./FrontmatterExtension";
 import { HeadingExtension } from "./HeadingExtension";
@@ -24,4 +25,5 @@ export const DefaultExtensions = [
     TableExtension,
     MarkdocTableExtension,
     MathBlockExtension,
+    CodeBlockGutterExtension
 ]


### PR DESCRIPTION
This pull request includes updates to the styling and functionality of the code editor, specifically focusing on the gutter display and the addition of line numbers for code blocks.

Styling updates:

* [`src/renderer/src/assets/Editor.scss`](diffhunk://#diff-b475f8b681130a35c32d5cb8989f764ffde83e76dc3688f18c3b7ebac7ca8d19L230-R256): Modified the gutter styling to hide line numbers and adjust the appearance of gutters during the development process.

Functional updates:

* [`src/renderer/src/cm-extensions/CodeBlockGutterExtension.ts`](diffhunk://#diff-75af7b3111bf9686d227821758dd2509eca1acd376ad4f7aaa081c61c36a1f2eR1-R53): Added a new extension to display line numbers within code blocks using the CodeMirror library.
* [`src/renderer/src/cm-extensions/index.ts`](diffhunk://#diff-76170153287318b8a7809995979c2b5e9bd1e0169b11952b487b34f0a543ce1aR3): Imported the new `CodeBlockGutterExtension` and included it in the default extensions array. [[1]](diffhunk://#diff-76170153287318b8a7809995979c2b5e9bd1e0169b11952b487b34f0a543ce1aR3) [[2]](diffhunk://#diff-76170153287318b8a7809995979c2b5e9bd1e0169b11952b487b34f0a543ce1aR28)