### PR TITLE
fix: add missing tailwindcss/colors import

### DIFF
--- a/src/renderer/src/cm-extensions/CodeBlockExtension.ts
+++ b/src/renderer/src/cm-extensions/CodeBlockExtension.ts
@@ -4,7 +4,7 @@ import { SyntaxNodeRef } from '@lezer/common';
 import { RangeSetBuilder } from '@uiw/react-codemirror';
 import icons from "@shared/assets/icons.json"
 import { createElement, Clipboard, ClipboardCheck } from 'lucide'
-import { size } from 'lodash';
+import colors from 'tailwindcss/colors'
 
 const tokenFormattingClasses = {
   InlineCodeText: Decoration.mark({ class: 'cm-formatting-inline-code-text' }),


### PR DESCRIPTION
This pull request includes a small change to the `CodeBlockExtension.ts` file. The change replaces the import of `size` from 'lodash' with an import of `colors` from 'tailwindcss'.

Change in imports:

* [`src/renderer/src/cm-extensions/CodeBlockExtension.ts`](diffhunk://#diff-c1a96e25fc2e15bdf5466d15c25fff8cb6253ddbf153208cbacad12dbaa3083fL7-R7): Replaced `size` from 'lodash' with `colors` from 'tailwindcss'.