### PR TITLE
fix: ensure new files are focused in editor and properly initialized

### DIFF
--- a/src/renderer/src/store/NotesStore.ts
+++ b/src/renderer/src/store/NotesStore.ts
@@ -2,10 +2,6 @@ import { getNotesDirectoryPath } from "@shared/constants";
 import { FileItem } from "@shared/models";
 import { atom } from "jotai";
 import { atomFamily } from "jotai/utils";
-import {
-  fileHistoryBackwardStackAtom,
-  fileHistoryForwardStackAtom,
-} from "./FileNavigationStore";
 
 // Editor-wide config
 export const isInitializedAtom = atom(false);
@@ -58,21 +54,6 @@ export const renamingStateFamily = atomFamily((filePath: string) =>
   atom(false)
 );
 
-// Opening newly created note
-export const openNoteAtom = atom(null, (get, set, file: FileItem) => {
-  const backStack = get(fileHistoryBackwardStackAtom);
-  const last = backStack[backStack.length - 1];
-
-  // Only push if not duplicate
-  if (!last || last.path !== file.path) {
-    set(fileHistoryBackwardStackAtom, [...backStack, file]);
-  }
-
-  set(fileHistoryForwardStackAtom, []);
-  set(currentFilePathAtom, file.path);
-  set(editorNoteTextAtom, "");
-  set(noteTextAtom, "");
-});
 
 // Bookmarks related atoms
 export const bookmarksAtom = atom<FileItem[]>([]);


### PR DESCRIPTION
This pull request refactors how newly created files are opened and improves image file handling in the file actions hooks. The main changes simplify state management by removing the `openNoteAtom` and updating the logic to use the shared `open` function. Additionally, image file detection is now more robust by using a centralized list of supported image MIME types.

**File opening and creation logic:**
* Removed the `openNoteAtom` from `NotesStore.ts` and updated file creation logic to use the `open` function directly, simplifying state management and reducing duplication. [[1]](diffhunk://#diff-7525d32d243e222d66e06e4b370a1a5cb06e0d74fb26da68c16c47a75f18375aL61-L75) [[2]](diffhunk://#diff-42adbff29a27dfc58f9749c902e2f0db888524a659a10d5cbfb77b00adb27837R208-R213) [[3]](diffhunk://#diff-42adbff29a27dfc58f9749c902e2f0db888524a659a10d5cbfb77b00adb27837L273-R278)
* When a new file is created, it is now opened using the `open` function, ensuring consistent behavior with other file actions.

**Image file handling:**
* Replaced the previous image MIME type check with a centralized `SUPPORTED_IMAGE_MIME_TYPES` constant for more reliable detection and future extensibility. [[1]](diffhunk://#diff-42adbff29a27dfc58f9749c902e2f0db888524a659a10d5cbfb77b00adb27837R25) [[2]](diffhunk://#diff-42adbff29a27dfc58f9749c902e2f0db888524a659a10d5cbfb77b00adb27837L103-R102)

**Code cleanup:**
* Removed unused imports from both `useFileActions.tsx` and `NotesStore.ts` for better maintainability. [[1]](diffhunk://#diff-42adbff29a27dfc58f9749c902e2f0db888524a659a10d5cbfb77b00adb27837L14) [[2]](diffhunk://#diff-42adbff29a27dfc58f9749c902e2f0db888524a659a10d5cbfb77b00adb27837L34) [[3]](diffhunk://#diff-7525d32d243e222d66e06e4b370a1a5cb06e0d74fb26da68c16c47a75f18375aL5-L8)